### PR TITLE
Fix Windows draft serve (tzdata, BOM, progress)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Windows draft-path fixes: depend on `tzdata` for `America/New_York`,
+  accept UTF-8 BOM in settings/board JSON, and print pool-load progress
+  so `python -m draft serve` does not hang silently on first boot.
 - Draft board: localhost page (`python -m draft serve`) for manual pick
   entry, snake-turn math, and drafted vs available from the player
   pool. No Yahoo poll. State in `$CI_STATE_DIR/draft-board.json`

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ New-Item -ItemType Directory -Force -Path $env:CI_STATE_DIR | Out-Null
 podman compose up --build
 ```
 
+On Windows, always activate `.venv` before `python -m …`. Bare `python`
+on PATH may be PlatformIO or the Store stub, which will not see this
+package (`No module named draft`). `America/New_York` needs the
+`tzdata` package (pulled in by `pip install -e ".[dev]"`).
+
 If the Windows/WSL volume mount fails, the real runtime is a Linux VPS
 where `/srv/ci/` is a native path. Do not spend draft week debugging
 the mount.
@@ -145,12 +150,18 @@ clicks in the Yahoo room and records each pick on a local page.
 
 1. `$CI_STATE_DIR/league-settings.json` has the real `team_count`,
    `draft.rounds`, and `draft.type` of `snake`.
-2. Start the page **before the room opens**:
-   `python -m draft serve`
+2. Start the page **before the room opens** (venv + `CI_STATE_DIR`
+   required on Windows):
+   ```powershell
+   .\.venv\Scripts\Activate.ps1
+   $env:CI_STATE_DIR = "$env:USERPROFILE\.local\share\ci"
+   python -m draft serve
+   ```
    First boot builds `$CI_STATE_DIR/player-pool.json` from the live
-   providers (same tokens as `player-pool`). Later boots reuse that
-   snapshot. `--refresh` rebuilds it. `--season` defaults to the
-   current year in `America/New_York`.
+   providers (same tokens as `player-pool`) and prints progress while
+   it runs. Later boots reuse that snapshot. `--refresh` rebuilds it.
+   `--season` defaults to the current year in `America/New_York`.
+   `draft.type` must be `"snake"`.
 3. Open `http://127.0.0.1:8765/`. Enter our draft slot (1-based).
    Team count is not typed here — edit the settings file if the
    room grew; the page re-reads it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ requires-python = ">=3.11"
 readme = "README.md"
 dependencies = [
     "httpx>=0.27",
+    # Windows zoneinfo has no IANA database; required for America/New_York.
+    "tzdata>=2024.1",
 ]
 
 [project.optional-dependencies]

--- a/src/data/league_settings.py
+++ b/src/data/league_settings.py
@@ -113,7 +113,8 @@ def load_league_settings(root: Path | None = None) -> LeagueSettings:
 
 def load_league_settings_file(path: Path) -> LeagueSettings:
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
+        # utf-8-sig: Windows editors / PowerShell often write a BOM.
+        raw = json.loads(path.read_text(encoding="utf-8-sig"))
     except FileNotFoundError as exc:
         raise LeagueSettingsError(f"missing file: {path}. {_TEMPLATE_HINT}") from exc
     except json.JSONDecodeError as exc:

--- a/src/draft/__main__.py
+++ b/src/draft/__main__.py
@@ -52,9 +52,17 @@ def _serve(host: str, port: int, season: int, refresh: bool) -> int:
         root = state_dir()
         settings = load_league_settings(root)
         require_snake(settings)
+        print(
+            f"loading player pool for {settings.team_count} teams / "
+            f"{settings.draft.rounds} rounds...",
+            flush=True,
+        )
         pool = load_draft_pool(root, settings, season=season, refresh=refresh)
     except (DraftError, DataError) as exc:
         print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"error: unexpected failure starting draft board: {exc}", file=sys.stderr)
         return 1
     app = DraftApp(root, pool)
     httpd = start_server(app, host=host, port=port)
@@ -62,7 +70,8 @@ def _serve(host: str, port: int, season: int, refresh: bool) -> int:
     print(
         f"ok: draft board at http://{host}:{bound}/ "
         f"({len(pool.players)} players, "
-        f"{settings.team_count} teams, {settings.draft.rounds} rounds)"
+        f"{settings.team_count} teams, {settings.draft.rounds} rounds)",
+        flush=True,
     )
     try:
         httpd.serve_forever()

--- a/src/draft/io.py
+++ b/src/draft/io.py
@@ -33,7 +33,7 @@ def load_board(root: Path, team_count: int, rounds: int) -> DraftBoard:
     if not path.exists():
         return new_board(team_count, rounds)
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw = json.loads(path.read_text(encoding="utf-8-sig"))
     except json.JSONDecodeError as exc:
         raise DraftStateError(f"invalid JSON in {path}: {exc}") from exc
     if not isinstance(raw, dict):
@@ -54,7 +54,7 @@ def save_board(root: Path, board: DraftBoard) -> None:
 
 def load_pool_snapshot(path: Path) -> PlayerPool:
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw = json.loads(path.read_text(encoding="utf-8-sig"))
     except FileNotFoundError as exc:
         raise DraftConfigError(f"missing player-pool snapshot: {path}") from exc
     except json.JSONDecodeError as exc:

--- a/src/draft/pool_load.py
+++ b/src/draft/pool_load.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from data import DataError
 from data.fantasypros import FantasyProsClient
@@ -24,10 +24,25 @@ def load_draft_pool(
     season: int = 0,
     refresh: bool = False,
 ) -> PlayerPool:
-    year = season or datetime.now(ZoneInfo("America/New_York")).year
+    if season:
+        year = season
+    else:
+        try:
+            year = datetime.now(ZoneInfo("America/New_York")).year
+        except ZoneInfoNotFoundError as exc:
+            raise DraftConfigError(
+                "could not resolve America/New_York; install the tzdata package "
+                f"(pip install tzdata). Underlying error: {exc}"
+            ) from exc
     snap = pool_snapshot_path(root)
     if snap.exists() and not refresh:
+        print(f"using snapshot {snap}", flush=True)
         return load_pool_snapshot(snap)
+    print(
+        "building player pool from FantasyPros + Tank01 "
+        "(first boot; may take a minute)...",
+        flush=True,
+    )
     try:
         with (
             FantasyProsClient(fantasypros_state_dir(root)) as fp,
@@ -43,4 +58,5 @@ def load_draft_pool(
             + f": {exc}"
         ) from exc
     save_pool_snapshot(snap, pool)
+    print(f"wrote snapshot {snap} ({len(pool.players)} players)", flush=True)
     return pool

--- a/tests/test_league_settings.py
+++ b/tests/test_league_settings.py
@@ -84,6 +84,15 @@ def test_invalid_json(tmp_path: Path) -> None:
         load_league_settings(tmp_path)
 
 
+def test_accepts_utf8_bom(tmp_path: Path) -> None:
+    """PowerShell Set-Content often writes a BOM; Windows editors too."""
+    path = tmp_path / "league-settings.json"
+    payload = json.dumps(_minimal(8))
+    path.write_bytes(b"\xef\xbb\xbf" + payload.encode("utf-8"))
+    settings = load_league_settings_file(path)
+    assert settings.team_count == 8
+
+
 def test_missing_required_key(tmp_path: Path) -> None:
     payload = _minimal()
     del payload["team_count"]


### PR DESCRIPTION
## Summary
- Add `tzdata` so `America/New_York` works on Windows.
- Read league-settings / draft JSON with `utf-8-sig` (PowerShell BOM).
- Print pool-load progress and catch unexpected startup errors as `error:` instead of a traceback.

## Assumptions Made
- Operator path was not dry-run on Windows before #46; this closes that gap after the fact.

## Quality gates
- [x] All tests passing (targeted + BOM regression)
- [x] Lint clean
- [x] Live smoke: `python -m draft serve` returns the page on 127.0.0.1:8765 with a built player-pool snapshot

## Known Limitations
- `league-settings.json` still needs real Yahoo values (`team_count`, rounds, scoring). Template fakes with `draft.type=snake` only get the page to boot.

Made with [Cursor](https://cursor.com)