### PR TITLE
Add kb.db schema and migrate CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- kb.db ledger schema and `python -m db migrate`: ten tables from
+  architecture §7, `season_id` on runs/deploys/config_changes (D-74),
+  WAL connections, failed-run `failure_mode` (D-63). Runtime file is
+  `$CI_STATE_DIR/kb.db`. Library callers pass an explicit state dir
+  (D-90).
 - Restructure the draft-week plan: workstation `python -m draft serve`
   remains the operational floor, but draft council logging moves
   pre-draft (`kb.db` schema + draft `considered_options` capture).

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ tiers are issue 10. Binds localhost only. Delete
 ### Decision ledger (kb.db)
 
 `kb.db` is the structured decision ledger on the state volume (D-74).
-Create or upgrade it with:
+Create it with:
 
 ```powershell
 python -m db migrate
@@ -188,7 +188,10 @@ python -m db migrate
 
 `--state-dir` overrides `$CI_STATE_DIR`. Tests and rehearsal must pass
 an explicit directory; do not point a mock run at the live root
-(D-90 / D-92). Council writes land in a later issue.
+(D-90 / D-92). The migrator applies `CREATE TABLE IF NOT EXISTS` and
+does not ALTER an existing file. Council writes (which must insert a
+`seasons` row before any `runs` / `deploys` / `config_changes` row)
+land in a later issue.
 
 | JSON field | Yahoo settings page |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -177,6 +177,19 @@ tiers are issue 10. Binds localhost only. Delete
 `draft-board.json` to start a session over. Changing `team_count` or
 `draft.rounds` after picks exist fails loud.
 
+### Decision ledger (kb.db)
+
+`kb.db` is the structured decision ledger on the state volume (D-74).
+Create or upgrade it with:
+
+```powershell
+python -m db migrate
+```
+
+`--state-dir` overrides `$CI_STATE_DIR`. Tests and rehearsal must pass
+an explicit directory; do not point a mock run at the live root
+(D-90 / D-92). Council writes land in a later issue.
+
 | JSON field | Yahoo settings page |
 |---|---|
 | `team_count` | Number of teams |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dev = [
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+db = ["schema.sql"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -1,1 +1,13 @@
-"""Decision ledger (scaffold). Schema lands in the week-1 kb.db issue."""
+"""Decision ledger: schema, migrate, and WAL connections."""
+
+from db.errors import DbConfigError, DbError
+from db.ledger import connect, migrate
+from db.paths import db_path
+
+__all__ = [
+    "DbConfigError",
+    "DbError",
+    "connect",
+    "db_path",
+    "migrate",
+]

--- a/src/db/__main__.py
+++ b/src/db/__main__.py
@@ -1,0 +1,46 @@
+"""CLI: apply the kb.db schema on the state volume."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from db.errors import DbError
+from db.ledger import migrate
+from db.paths import state_dir
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m db")
+    sub = parser.add_subparsers(dest="command", required=True)
+    migrate_cmd = sub.add_parser(
+        "migrate",
+        help="create $CI_STATE_DIR/kb.db and apply the ledger schema",
+    )
+    migrate_cmd.add_argument(
+        "--state-dir",
+        type=Path,
+        help="state directory (default: $CI_STATE_DIR or /srv/ci)",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    if args.command == "migrate":
+        return _migrate(args.state_dir)
+    print(f"error: unknown command {args.command!r}", file=sys.stderr)
+    return 2
+
+
+def _migrate(override: Path | None) -> int:
+    try:
+        root = state_dir(override)
+        path = migrate(root)
+    except DbError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"ok: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/db/errors.py
+++ b/src/db/errors.py
@@ -1,0 +1,9 @@
+"""Ledger errors. Write-path failures must not be swallowed."""
+
+
+class DbError(Exception):
+    """Base for every kb.db failure."""
+
+
+class DbConfigError(DbError):
+    """Missing state dir, missing schema file, or migrate/connect failure."""

--- a/src/db/ledger.py
+++ b/src/db/ledger.py
@@ -1,0 +1,60 @@
+"""Open and migrate kb.db. Callers pass an explicit state root (D-90)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from db.errors import DbConfigError
+from db.paths import db_path
+
+_SCHEMA_NAME = "schema.sql"
+_BUSY_TIMEOUT_MS = 5000
+_USER_VERSION = 1
+
+
+def _schema_sql() -> str:
+    path = Path(__file__).with_name(_SCHEMA_NAME)
+    if not path.is_file():
+        raise DbConfigError(
+            f"missing schema file {path}. Reinstall the package so "
+            "schema.sql ships next to the db module."
+        )
+    return path.read_text(encoding="utf-8")
+
+
+def connect(root: Path) -> sqlite3.Connection:
+    """Open {root}/kb.db in WAL mode with foreign keys on.
+
+    Each caller (including each specialist thread) opens its own
+    connection. busy_timeout lets parallel writes wait instead of
+    raising SQLITE_BUSY.
+    """
+    path = db_path(root)
+    try:
+        conn = sqlite3.connect(path)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
+    except sqlite3.Error as exc:
+        raise DbConfigError(f"failed to open {path}: {exc}") from exc
+    return conn
+
+
+def migrate(root: Path) -> Path:
+    """Create {root}/kb.db and apply schema.sql. Idempotent.
+
+    mkdir only the given root. Never resolves CI_STATE_DIR.
+    """
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise DbConfigError(f"cannot create state dir {root}: {exc}") from exc
+    path = db_path(root)
+    try:
+        with connect(root) as conn:
+            conn.executescript(_schema_sql())
+            conn.execute(f"PRAGMA user_version={_USER_VERSION}")
+    except sqlite3.Error as exc:
+        raise DbConfigError(f"failed to migrate {path}: {exc}") from exc
+    return path

--- a/src/db/ledger.py
+++ b/src/db/ledger.py
@@ -42,9 +42,11 @@ def connect(root: Path) -> sqlite3.Connection:
 
 
 def migrate(root: Path) -> Path:
-    """Create {root}/kb.db and apply schema.sql. Idempotent.
+    """Create {root}/kb.db and apply schema.sql. Idempotent for v1.
 
-    mkdir only the given root. Never resolves CI_STATE_DIR.
+    mkdir only the given root. Never resolves CI_STATE_DIR. Does not
+    ALTER an existing database; a later schema bump needs a new
+    migration path.
     """
     try:
         root.mkdir(parents=True, exist_ok=True)

--- a/src/db/paths.py
+++ b/src/db/paths.py
@@ -1,0 +1,37 @@
+"""Resolve kb.db on an explicit state root. Library callers pass a Path."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from db.errors import DbConfigError
+
+_FILENAME = "kb.db"
+_LINUX_DEFAULT = Path("/srv/ci")
+_HINT = (
+    "Set CI_STATE_DIR to a directory outside the git worktree, then "
+    "run python -m db migrate. Tests and rehearsal must pass an "
+    "explicit --state-dir (D-90)."
+)
+
+
+def state_dir(override: Path | None = None) -> Path:
+    """Return CI_STATE_DIR, or /srv/ci when that directory exists.
+
+    Unset CI_STATE_DIR on a workstation (no /srv/ci) is a config error,
+    not a silent write into the repo.
+    """
+    if override is not None:
+        return override
+    raw = os.environ.get("CI_STATE_DIR")
+    if raw:
+        return Path(raw)
+    if _LINUX_DEFAULT.is_dir():
+        return _LINUX_DEFAULT
+    raise DbConfigError("CI_STATE_DIR is not set and /srv/ci does not exist. " + _HINT)
+
+
+def db_path(root: Path) -> Path:
+    """Return {root}/kb.db. root is required; this never reads the env."""
+    return root / _FILENAME

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS briefs (
 CREATE TABLE IF NOT EXISTS considered_options (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     run_id INTEGER NOT NULL REFERENCES runs (id),
-    persona TEXT,
+    persona TEXT NOT NULL,
     player_key TEXT NOT NULL,
     contemplated_action TEXT NOT NULL,
     projection_primary REAL,

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1,3 +1,122 @@
--- kb.db schema. Tables land in the week-1 issue
--- "kb.db schema: ledger, attribution, deploys, config changes".
--- Do not invent tables here. season_id is required from the first write (D-74).
+-- kb.db decision ledger. Tables are the architecture §7 draft list.
+-- season_id is required from the first write (D-74). Do not invent tables.
+-- Child tables inherit season through run_id.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS seasons (
+    season_id TEXT PRIMARY KEY,
+    league_key TEXT,
+    team_key TEXT,
+    start_date TEXT,
+    end_date TEXT,
+    final_record TEXT,
+    final_placing INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    season_id TEXT NOT NULL REFERENCES seasons (season_id),
+    ts TEXT NOT NULL,
+    decision_type TEXT NOT NULL,
+    packet_hash TEXT,
+    failure_mode TEXT,
+    publish_approved INTEGER NOT NULL DEFAULT 0,
+    publish_denied_reason TEXT,
+    manual_intervention INTEGER NOT NULL DEFAULT 0,
+    absent_personas TEXT
+);
+
+CREATE TABLE IF NOT EXISTS briefs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL REFERENCES runs (id),
+    persona TEXT NOT NULL,
+    recommendations TEXT,
+    confidence REAL,
+    reasoning TEXT,
+    dissent TEXT,
+    voice_line TEXT,
+    model TEXT,
+    tokens INTEGER,
+    cost REAL
+);
+
+CREATE TABLE IF NOT EXISTS considered_options (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL REFERENCES runs (id),
+    persona TEXT,
+    player_key TEXT NOT NULL,
+    contemplated_action TEXT NOT NULL,
+    projection_primary REAL,
+    projection_secondary REAL,
+    projection_delta REAL,
+    std_dev REAL,
+    injury_status TEXT,
+    chosen INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS decisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL REFERENCES runs (id),
+    final_actions TEXT NOT NULL,
+    adopted_from TEXT,
+    overruled TEXT,
+    override_reason TEXT,
+    unanimous_override INTEGER NOT NULL DEFAULT 0,
+    rationale TEXT
+);
+
+CREATE TABLE IF NOT EXISTS outcomes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL REFERENCES runs (id),
+    what_happened TEXT,
+    points_gained INTEGER,
+    points_lost INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS attributions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL REFERENCES runs (id),
+    persona TEXT NOT NULL,
+    counterfactual_points INTEGER,
+    directional_accuracy INTEGER,
+    brier_contribution REAL,
+    adopted INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS executions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL REFERENCES runs (id),
+    payload TEXT,
+    response TEXT,
+    errors TEXT,
+    pending_review INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS deploys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    season_id TEXT NOT NULL REFERENCES seasons (season_id),
+    ts TEXT NOT NULL,
+    commit_sha TEXT NOT NULL,
+    description TEXT NOT NULL,
+    touches_decision_logic INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS config_changes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    season_id TEXT NOT NULL REFERENCES seasons (season_id),
+    ts TEXT NOT NULL,
+    knob TEXT NOT NULL,
+    old_value TEXT,
+    new_value TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_runs_season_id ON runs (season_id);
+CREATE INDEX IF NOT EXISTS idx_briefs_run_id ON briefs (run_id);
+CREATE INDEX IF NOT EXISTS idx_considered_options_run_id ON considered_options (run_id);
+CREATE INDEX IF NOT EXISTS idx_decisions_run_id ON decisions (run_id);
+CREATE INDEX IF NOT EXISTS idx_outcomes_run_id ON outcomes (run_id);
+CREATE INDEX IF NOT EXISTS idx_attributions_run_id ON attributions (run_id);
+CREATE INDEX IF NOT EXISTS idx_executions_run_id ON executions (run_id);
+CREATE INDEX IF NOT EXISTS idx_deploys_season_id ON deploys (season_id);
+CREATE INDEX IF NOT EXISTS idx_config_changes_season_id ON config_changes (season_id);

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -50,6 +50,7 @@ def test_migrate_creates_tables_and_season_id_columns(tmp_path: Path) -> None:
         assert "publish_approved" in _columns(conn, "runs")
         assert "publish_denied_reason" in _columns(conn, "runs")
         assert "manual_intervention" in _columns(conn, "runs")
+        assert "absent_personas" in _columns(conn, "runs")
         version = conn.execute("PRAGMA user_version").fetchone()[0]
         assert version == 1
 
@@ -144,6 +145,35 @@ def test_cli_migrate_state_dir(
     assert (tmp_path / "kb.db").is_file()
 
 
+def test_foreign_keys_reject_orphans(tmp_path: Path) -> None:
+    migrate(tmp_path)
+    with connect(tmp_path) as conn:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO runs (season_id, ts, decision_type)
+                VALUES ('2026', '2026-09-04T12:00:00-04:00', 'draft')
+                """
+            )
+        conn.execute("INSERT INTO seasons (season_id) VALUES ('2026')")
+        conn.execute(
+            """
+            INSERT INTO runs (season_id, ts, decision_type)
+            VALUES ('2026', '2026-09-04T12:00:00-04:00', 'draft')
+            """
+        )
+        run_id = conn.execute("SELECT id FROM runs").fetchone()[0]
+        conn.commit()
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO briefs (run_id, persona, reasoning)
+                VALUES (?, 'belichuk', 'ok')
+                """,
+                (run_id + 99,),
+            )
+
+
 def test_cli_migrate_from_env(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -152,7 +182,10 @@ def test_cli_migrate_from_env(
     monkeypatch.setenv("CI_STATE_DIR", str(tmp_path))
     assert main(["migrate"]) == 0
     out = capsys.readouterr().out
-    assert str(tmp_path / "kb.db") in out.replace("\\", "/") or "kb.db" in out
+    written = tmp_path / "kb.db"
+    assert written.is_file()
+    assert out.startswith("ok:")
+    assert Path(out.split("ok:", 1)[1].strip()) == written
 
 
 def test_unset_ci_state_dir(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from db import DbConfigError, connect, db_path, migrate
+from db.__main__ import main
+from db.paths import state_dir
+
+REQUIRED_TABLES = {
+    "seasons",
+    "runs",
+    "briefs",
+    "considered_options",
+    "decisions",
+    "outcomes",
+    "attributions",
+    "executions",
+    "deploys",
+    "config_changes",
+}
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {row[1] for row in rows}
+
+
+def test_db_path_is_under_explicit_root(tmp_path: Path) -> None:
+    assert db_path(tmp_path) == tmp_path / "kb.db"
+
+
+def test_migrate_creates_tables_and_season_id_columns(tmp_path: Path) -> None:
+    path = migrate(tmp_path)
+    assert path == tmp_path / "kb.db"
+    assert path.is_file()
+    with connect(tmp_path) as conn:
+        names = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        assert REQUIRED_TABLES <= names
+        assert "season_id" in _columns(conn, "runs")
+        assert "season_id" in _columns(conn, "deploys")
+        assert "season_id" in _columns(conn, "config_changes")
+        assert "failure_mode" in _columns(conn, "runs")
+        assert "publish_approved" in _columns(conn, "runs")
+        assert "publish_denied_reason" in _columns(conn, "runs")
+        assert "manual_intervention" in _columns(conn, "runs")
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == 1
+
+
+def test_migrate_is_idempotent(tmp_path: Path) -> None:
+    first = migrate(tmp_path)
+    second = migrate(tmp_path)
+    assert first == second
+    with connect(tmp_path) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        assert REQUIRED_TABLES <= tables
+
+
+def test_wal_mode(tmp_path: Path) -> None:
+    migrate(tmp_path)
+    with connect(tmp_path) as conn:
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode.lower() == "wal"
+
+
+def test_failed_run_is_a_row(tmp_path: Path) -> None:
+    migrate(tmp_path)
+    with connect(tmp_path) as conn:
+        conn.execute(
+            "INSERT INTO seasons (season_id) VALUES (?)",
+            ("2026",),
+        )
+        conn.execute(
+            """
+            INSERT INTO runs (season_id, ts, decision_type, failure_mode)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("2026", "2026-09-04T12:00:00-04:00", "draft", "gm_timeout"),
+        )
+        conn.execute(
+            """
+            INSERT INTO runs (season_id, ts, decision_type)
+            VALUES (?, ?, ?)
+            """,
+            ("2026", "2026-09-04T12:01:00-04:00", "draft"),
+        )
+        conn.commit()
+        rows = conn.execute(
+            "SELECT failure_mode, publish_approved FROM runs ORDER BY id"
+        ).fetchall()
+    assert rows[0] == ("gm_timeout", 0)
+    assert rows[1] == (None, 0)
+
+
+def test_parallel_specialist_writes(tmp_path: Path) -> None:
+    migrate(tmp_path)
+    with connect(tmp_path) as conn:
+        conn.execute("INSERT INTO seasons (season_id) VALUES ('2026')")
+        conn.execute(
+            """
+            INSERT INTO runs (season_id, ts, decision_type)
+            VALUES ('2026', '2026-09-04T12:00:00-04:00', 'draft')
+            """
+        )
+        run_id = conn.execute("SELECT id FROM runs").fetchone()[0]
+        conn.commit()
+
+    def _write(persona: str) -> None:
+        with connect(tmp_path) as inner:
+            inner.execute(
+                """
+                INSERT INTO briefs (run_id, persona, reasoning)
+                VALUES (?, ?, ?)
+                """,
+                (run_id, persona, "ok"),
+            )
+            inner.commit()
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        list(pool.map(_write, ("belichuk", "brand", "taco", "maddox")))
+
+    with connect(tmp_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM briefs").fetchone()[0]
+    assert count == 4
+
+
+def test_cli_migrate_state_dir(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["migrate", "--state-dir", str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+    assert out.startswith("ok:")
+    assert "kb.db" in out
+    assert (tmp_path / "kb.db").is_file()
+
+
+def test_cli_migrate_from_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("CI_STATE_DIR", str(tmp_path))
+    assert main(["migrate"]) == 0
+    out = capsys.readouterr().out
+    assert str(tmp_path / "kb.db") in out.replace("\\", "/") or "kb.db" in out
+
+
+def test_unset_ci_state_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CI_STATE_DIR", raising=False)
+    monkeypatch.setattr("db.paths._LINUX_DEFAULT", Path("/nonexistent-ci-state"))
+    with pytest.raises(DbConfigError, match="CI_STATE_DIR"):
+        state_dir()


### PR DESCRIPTION
## Summary
- Add the ten-table `kb.db` ledger (architecture §7) with `season_id` on runs, deploys, and config_changes from the first write (D-74).
- `python -m db migrate [--state-dir]` creates `{state}/kb.db` in WAL mode. Library `connect` / `migrate` / `db_path` require an explicit Path so tests never touch the live state dir (D-90).
- Failed runs are first-class rows (`failure_mode`); `publish_approved` defaults to false. Council insert helpers stay in issue 11.

## Assumptions Made
- This issue is schema + migrate + connect only. No insert DAOs (issue 11 writes `runs` / `briefs`).
- `season_id` is TEXT (e.g. `2026`) to match the MQTT path (D-77).
- A `seasons` row is required before any `runs` / `deploys` / `config_changes` insert (FK). `migrate` does not seed a season.
- Extra `runs` columns from §7.4 / §9.2.1 (`failure_mode`, `publish_approved`, `publish_denied_reason`, `manual_intervention`, `absent_personas`) ship in v1 so issue 11 does not migrate.
- D-92 rehearsal refusal is issue 12. This CLI accepts an explicit `--state-dir` and does not refuse the live root.
- No `UNIQUE(run_id, persona)` on briefs/attributions so a specialist retry can write another row.

## Quality gates
- [x] All tests passing
- [x] Lint clean
- [x] Code critique: PASS WITH CHANGES (README/FK tests fixed; remaining notes in Known Limitations)
- [x] No regressions

## Known Limitations
- The migrator is create-only (`CREATE TABLE IF NOT EXISTS`). It does not ALTER an existing `kb.db`.
- No unique constraint on briefs/attributions per run+persona.

Closes #15

Made with [Cursor](https://cursor.com)