### PR TITLE
List default OpenRouter slugs in the token template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `templates/openrouter.json` lists the default per-persona OpenRouter
+  slugs so a live copy can override them without reading the code.
 - Council orchestrator (`python -m council run`): OpenRouter key from
   `$CI_STATE_DIR/tokens/openrouter.json`, specialists in parallel,
   brief/GM schema validation (malformed and unknown `player_key`

--- a/templates/openrouter.json
+++ b/templates/openrouter.json
@@ -1,4 +1,12 @@
 {
-  "_readme": "FAKE VALUE. Copy this file to $CI_STATE_DIR/tokens/openrouter.json and replace api_key. Never put the real key in this templates/ copy. Optional \"models\" object overrides the default OpenRouter slug per persona.",
-  "api_key": "REPLACE_ME"
+  "_readme": "FAKE VALUE. Copy this file to $CI_STATE_DIR/tokens/openrouter.json and replace api_key. Never put the real key in this templates/ copy. models slugs are the code defaults — edit the live copy to override a persona.",
+  "api_key": "REPLACE_ME",
+  "models": {
+    "belichuk": "anthropic/claude-sonnet-4.5",
+    "brand": "openai/gpt-4o",
+    "taco": "deepseek/deepseek-chat",
+    "muskett": "x-ai/grok-4",
+    "maddox": "google/gemini-2.5-pro",
+    "lasso": "google/gemini-2.5-flash"
+  }
 }


### PR DESCRIPTION
## Summary
- `templates/openrouter.json` now includes the six default per-persona OpenRouter slugs next to the placeholder key.
- A live copy can override one model without reading `council.credentials.DEFAULT_MODELS`.

## Assumptions Made
- None

## Quality gates
- [x] All tests passing
- [x] Lint clean
- [x] Code critique: skipped at operator request
- [x] No regressions

## Known Limitations
- None. Recopy or merge `models` into an already-copied live token file; the template change does not update `$CI_STATE_DIR`.
